### PR TITLE
Use a form element instead of a div as wrapper

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,10 +25,16 @@ var Submittable = React.createClass({
       }
     }
   },
+  onSubmit: function(event) {
+    event.preventDefault();
+  },
   render: function render() {
     return React.createElement(
-      'div',
-      _extends({ onKeyDown: this.onKeyDown }, this.props),
+      'form',
+      _extends({
+        onKeyDown: this.onKeyDown,
+        onSubmit: this.onSubmit
+      }, this.props),
       this.props.children
     );
   }


### PR DESCRIPTION
This means that we do have an onSubmit event to track, but
also that default browser behavior, like offering to save
passwords, will work correctly.

cc @scothis 
