### PR TITLE
Update testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+*.log
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "4"

--- a/__tests__/submittable-test.js
+++ b/__tests__/submittable-test.js
@@ -1,39 +1,29 @@
-jest.dontMock('../index.js');
-describe('Submittable', function() {
-  it('calls onEnter when it gets an enter event', function(done) {
-    var React = require('react/addons');
-    var Submittable = require('../index.js');
-    var TestUtils = React.addons.TestUtils;
+var React = require('react');
+var enzyme = require('enzyme');
+var Submittable = require('../index.js');
 
+describe('Submittable', function() {
+  it('calls onEnter when it gets an enter event', function() {
     // Render a checkbox with label in the document
-    var pseudoForm = TestUtils.renderIntoDocument(
+    var wrapper = enzyme.mount(
       <Submittable onEnter={onEnter}>
         <input type='text' />
       </Submittable>);
 
     var onEnterCalled = false;
-    function onEnter(event) {
+    function onEnter() {
       onEnterCalled = true;
     }
 
     // Simulate a click and verify that it is now On
-    var input = TestUtils.findRenderedDOMComponentWithTag(
-      pseudoForm, 'input');
+    wrapper.find('input').simulate('keyDown', { key: 'Enter', keyCode: 13 });
 
-    TestUtils.Simulate.keyDown(input, { key: "Enter", keyCode: 13 });
-
-    waitsFor(function() {
-      return onEnterCalled;
-    });
+    expect(onEnterCalled).toBe(true);
   });
 
-  it('calls onCancel when it gets an exit event and has a binding', function(done) {
-    var React = require('react/addons');
-    var Submittable = require('../index.js');
-    var TestUtils = React.addons.TestUtils;
-
+  it('calls onCancel when it gets an exit event and has a binding', function() {
     // Render a checkbox with label in the document
-    var pseudoForm = TestUtils.renderIntoDocument(
+    var wrapper = enzyme.mount(
       <Submittable
         onCancel={onCancel}
         onEnter={onEnter}>
@@ -51,13 +41,8 @@ describe('Submittable', function() {
     }
 
     // Simulate a click and verify that it is now On
-    var input = TestUtils.findRenderedDOMComponentWithTag(
-      pseudoForm, 'input');
+    wrapper.find('input').simulate('keyDown', { key: "Escape", keyCode: 27 });
 
-    TestUtils.Simulate.keyDown(input, { key: "Escape", keyCode: 27 });
-
-    waitsFor(function() {
-      return onCancelCalled;
-    });
+    expect(onCancelCalled).toBe(true);
   });
 });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "a replacement for preventing the default behavior of forms: allows submission on enter",
   "main": "index.js",
   "scripts": {
-    "test": "jest && coveralls < coverage/lcov.info"
+    "jest": "jest",
+    "test": "npm run jest"
   },
   "keywords": [
     "submit",
@@ -15,16 +16,17 @@
   "author": "Tom MacWright",
   "license": "ISC",
   "devDependencies": {
-    "jest-cli": "^0.4.18",
-    "coveralls": "^2.11.4",
-    "react-tools": "^0.13.3"
+    "babel-jest": "^16.0.0",
+    "babel-preset-react": "^6.16.0",
+    "enzyme": "^2.4.1",
+    "jest": "^16.0.1",
+    "react-addons-test-utils": "^15.3.2",
+    "react-dom": "^15.3.2"
   },
-  "jest": {
-    "scriptPreprocessor": "<rootDir>/preprocessor.js",
-    "unmockedModulePathPatterns": [
-      "<rootDir>/node_modules/react"
-    ],
-    "collectCoverage": true
+  "babel": {
+    "presets": [
+      "react"
+    ]
   },
   "dependencies": {
     "react": "*"
@@ -32,5 +34,8 @@
   "repository": {
     "type": "git",
     "url": "git@github.com:mapbox/react-submittable.git"
+  },
+  "jest": {
+    "collectCoverage": true
   }
 }

--- a/preprocessor.js
+++ b/preprocessor.js
@@ -1,7 +1,0 @@
-// preprocessor.js
-var ReactTools = require('react-tools');
-module.exports = {
-  process: function(src) {
-    return ReactTools.transform(src);
-  }
-};


### PR DESCRIPTION
This PR updates the testing tools. 

Right now `npm test` after a fresh install does not actually work, because although the module accepts any version of React, it expects certain things (`react/addons`) that are outdated.

I've upgraded Jest and installed enzyme, changed the existing tests accordingly, and removed outdated dependencies.

I wanted to do this prior to taking care of https://github.com/mapbox/react-submittable/issues/3 so that I could write tests for that solution.

@tmcw for review.
